### PR TITLE
Make spc_player example support song length and fadeout

### DIFF
--- a/examples/spc_player.rs
+++ b/examples/spc_player.rs
@@ -47,6 +47,71 @@ struct SpcEndState {
 fn play_spc_file(file_name: &String) -> Result<()> {
     let spc = try!(Spc::load(file_name));
 
+    print_spc_file_info(file_name, &spc);
+
+    let mut apu = Apu::new();
+    apu.set_state(&spc);
+    // Most SPC's have crap in the echo buffer on startup, so while it's not technically correct, we'll clear that.
+    // The example for blargg's APU emulator (which is known to be the most accurate there is) also does this, so I
+    //  think we're OK to do it too :)
+    apu.clear_echo_buffer();
+
+    let (is_done_send, is_done_recv) = channel();
+
+    let mut driver = audio_driver_factory::create_default();
+    driver.set_sample_rate(SAMPLE_RATE as i32);
+    let mut left = Box::new([0; BUFFER_LEN]);
+    let mut right = Box::new([0; BUFFER_LEN]);
+
+    let mut end_state = if let Some(ref id666_tag) = spc.id666_tag {
+        let fade_out_sample = id666_tag.seconds_to_play_before_fading_out * (SAMPLE_RATE as i32);
+        let end_sample = fade_out_sample + id666_tag.fade_out_length * (SAMPLE_RATE as i32) / 1000;
+        Some(SpcEndState {
+            sample_pos: 0,
+            fade_out_sample: fade_out_sample,
+            end_sample: end_sample,
+            is_done_send: is_done_send.clone()
+        })
+    } else {
+        None
+    };
+
+    driver.set_render_callback(Some(Box::new(move |buffer, num_frames| {
+        apu.render(&mut *left, &mut *right, num_frames as i32);
+        match end_state {
+            Some(ref mut state) => {
+                for i in 0..num_frames {
+                    let j = i * 2;
+                    let sample_index = state.sample_pos + (i as i32);
+                    let f = if sample_index >= state.end_sample {
+                        0.0
+                    } else if sample_index >= state.fade_out_sample {
+                        1.0 - ((sample_index - state.fade_out_sample) as f32) / ((state.end_sample - state.fade_out_sample) as f32)
+                    } else {
+                        1.0
+                    };
+                    buffer[j + 0] = left[i] as f32 * f / 32768.0;
+                    buffer[j + 1] = right[i] as f32 * f / 32768.0;
+                }
+                state.sample_pos += num_frames as i32;
+                if state.sample_pos >= state.end_sample {
+                    state.is_done_send.send(()).ok();
+                }
+            },
+            _ => {
+                for i in 0..num_frames {
+                    let j = i * 2;
+                    buffer[j + 0] = left[i] as f32 / 32768.0;
+                    buffer[j + 1] = right[i] as f32 / 32768.0;
+                }
+            }
+        }
+    })));
+
+    wait_for_key_press_with_busy_icon(is_done_send, is_done_recv)
+}
+
+fn print_spc_file_info(file_name: &String, spc: &Spc) {
     println!("SPC: {}", file_name);
     println!(" Version Minor: {}", spc.version_minor);
     println!(" PC: {}", spc.pc);
@@ -75,72 +140,13 @@ fn play_spc_file(file_name: &String) -> Result<()> {
     } else {
         println!(" No ID666 tag present.");
     };
-
-    let mut apu = Apu::new();
-    apu.set_state(&spc);
-    // Most SPC's have crap in the echo buffer on startup, so while it's not technically correct, we'll clear that.
-    // The example for blargg's APU emulator (which is known to be the most accurate there is) also does this, so I
-    //  think we're OK to do it too :)
-    apu.clear_echo_buffer();
-
-    let (is_done_send, is_done_recv) = channel();
-
-    let mut driver = audio_driver_factory::create_default();
-    driver.set_sample_rate(SAMPLE_RATE as i32);
-    let mut left = Box::new([0; BUFFER_LEN]);
-    let mut right = Box::new([0; BUFFER_LEN]);
-    let mut end_state = if let Some(ref id666_tag) = spc.id666_tag {
-        let fade_out_sample = id666_tag.seconds_to_play_before_fading_out * (SAMPLE_RATE as i32);
-        let end_sample = fade_out_sample + id666_tag.fade_out_length * (SAMPLE_RATE as i32) / 1000;
-        Some(SpcEndState {
-            sample_pos: 0,
-            fade_out_sample: fade_out_sample,
-            end_sample: end_sample,
-            is_done_send: is_done_send.clone()
-        })
-    } else {
-        None
-    };
-    driver.set_render_callback(Some(Box::new(move |buffer, num_frames| {
-        apu.render(&mut *left, &mut *right, num_frames as i32);
-        match end_state {
-            Some(ref mut state) => {
-                for i in 0..num_frames {
-                    let j = i * 2;
-                    let sample_index = state.sample_pos + (i as i32);
-                    let f = if sample_index >= state.end_sample {
-                        0.0
-                    } else if sample_index >= state.fade_out_sample {
-                        1.0 - ((sample_index - state.fade_out_sample) as f32) / ((state.end_sample - state.fade_out_sample) as f32)
-                    } else {
-                        1.0
-                    };
-                    buffer[j + 0] = left[i] as f32 * f / 32768.0;
-                    buffer[j + 1] = right[i] as f32 * f / 32768.0;
-                }
-                state.sample_pos += num_frames as i32;
-                if state.sample_pos >= state.end_sample {
-                    state.is_done_send.send(()).unwrap();
-                }
-            },
-            _ => {
-                for i in 0..num_frames {
-                    let j = i * 2;
-                    buffer[j + 0] = left[i] as f32 / 32768.0;
-                    buffer[j + 1] = right[i] as f32 / 32768.0;
-                }
-            }
-        }
-    })));
-
-    wait_for_key_press_with_busy_icon(is_done_send, is_done_recv)
 }
 
 fn wait_for_key_press_with_busy_icon(is_done_send: Sender<()>, is_done_recv: Receiver<()>) -> Result<()> {
     thread::spawn(move || {
         let mut s = String::new();
-        stdin().read_line(&mut s).unwrap();
-        is_done_send.send(()).unwrap();
+        stdin().read_line(&mut s).ok();
+        is_done_send.send(()).ok();
     });
 
     println!("Return stops song.");
@@ -152,7 +158,7 @@ fn wait_for_key_press_with_busy_icon(is_done_send: Sender<()>, is_done_recv: Rec
         }
 
         print!("\r[{}]", chars[char_index]);
-        stdout().flush().unwrap();
+        stdout().flush().ok();
         char_index = (char_index + 1) % chars.len();
 
         thread::sleep_ms(5);


### PR DESCRIPTION
Also refactored the example to use channels instead of mutexes and polling effectively (well, there's still some polling, but only because we're also drawing a fun spinning indicator :D)
