### PR TITLE
Added ways to get/manipulate state at runtime, including voice solo/mutes and output buffers

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -48,6 +48,10 @@ impl Apu {
     }
 
     pub fn reset(&mut self) {
+        for i in 0..RAM_LEN {
+            self.ram[i] = 0;
+        }
+
         for i in 0..IPL_ROM_LEN {
             self.ipl_rom[i] = DEFAULT_IPL_ROM[i];
         }

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -173,6 +173,14 @@ impl Apu {
         }
     }
 
+    pub fn get_ram_snapshot(&mut self) -> Box<[u8; RAM_LEN]> {
+        let mut ret = Box::new([0; RAM_LEN]);
+        for i in 0..RAM_LEN {
+            ret[i] = self.read_u8(i as u32);
+        }
+        ret
+    }
+
     fn set_test_reg(&self, value: u8) {
         let _ = value;
         panic!("Test reg not yet implemented");

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -17,8 +17,8 @@ pub struct Apu {
     ram: Box<[u8; RAM_LEN]>,
     ipl_rom: Box<[u8; IPL_ROM_LEN]>,
 
-    smp: Option<Box<Smp>>,
-    dsp: Option<Box<Dsp>>,
+    pub smp: Option<Box<Smp>>,
+    pub dsp: Option<Box<Dsp>>,
 
     timers: [Timer; 3],
 
@@ -171,14 +171,6 @@ impl Apu {
         for i in dsp.get_echo_start_address() as i32..end_addr {
             self.ram[i as usize] = 0xff;
         }
-    }
-
-    pub fn get_ram_snapshot(&mut self) -> Box<[u8; RAM_LEN]> {
-        let mut ret = Box::new([0; RAM_LEN]);
-        for i in 0..RAM_LEN {
-            ret[i] = self.read_u8(i as u32);
-        }
-        ret
     }
 
     fn set_test_reg(&self, value: u8) {

--- a/src/dsp/dsp.rs
+++ b/src/dsp/dsp.rs
@@ -23,7 +23,7 @@ static COUNTER_OFFSETS: [i32; 32] = [
 pub struct Dsp {
     emulator: *mut Apu,
 
-    voices: Vec<Box<Voice>>,
+    pub voices: Vec<Box<Voice>>,
 
     left_filter: Box<Filter>,
     right_filter: Box<Filter>,

--- a/src/dsp/mod.rs
+++ b/src/dsp/mod.rs
@@ -1,7 +1,7 @@
 mod dsp_helpers;
 mod envelope;
 mod brr_block_decoder;
-mod voice;
+pub mod voice;
 mod filter;
 mod ring_buffer;
 pub mod dsp;

--- a/src/dsp/voice.rs
+++ b/src/dsp/voice.rs
@@ -31,7 +31,9 @@ pub struct Voice {
     sample_address: u32,
     sample_pos: i32,
     current_sample: i32,
-    next_sample: i32
+    next_sample: i32,
+
+    pub is_muted: bool
 }
 
 impl Voice {
@@ -57,7 +59,9 @@ impl Voice {
             sample_address: 0,
             sample_pos: 0,
             current_sample: 0,
-            next_sample: 0
+            next_sample: 0,
+
+            is_muted: false
         };
         ret.reset();
         ret
@@ -95,6 +99,8 @@ impl Voice {
         self.sample_pos = 0;
         self.current_sample = 0;
         self.next_sample = 0;
+
+        self.is_muted = false;
     }
 
     pub fn render_sample(&mut self, last_voice_out: i32, noise: i32) -> VoiceOutput {
@@ -141,10 +147,18 @@ impl Voice {
             }
         }
 
-        VoiceOutput {
-            left_out: dsp_helpers::multiply_volume(sample, self.vol_left),
-            right_out: dsp_helpers::multiply_volume(sample, self.vol_right),
-            last_voice_out: sample
+        if !self.is_muted {
+            VoiceOutput {
+                left_out: dsp_helpers::multiply_volume(sample, self.vol_left),
+                right_out: dsp_helpers::multiply_volume(sample, self.vol_right),
+                last_voice_out: sample
+            }
+        } else {
+            VoiceOutput {
+                left_out: 0,
+                right_out: 0,
+                last_voice_out: 0
+            }
         }
     }
 

--- a/src/dsp/voice.rs
+++ b/src/dsp/voice.rs
@@ -4,10 +4,51 @@ use super::envelope::Envelope;
 use super::brr_block_decoder::BrrBlockDecoder;
 use super::dsp_helpers;
 
+#[derive(Clone, Copy)]
 pub struct VoiceOutput {
     pub left_out: i32,
     pub right_out: i32,
     pub last_voice_out: i32
+}
+
+impl VoiceOutput {
+    pub fn default() -> VoiceOutput {
+        VoiceOutput {
+            left_out: 0,
+            right_out: 0,
+            last_voice_out: 0
+        }
+    }
+}
+
+pub const VOICE_BUFFER_LEN: usize = 128;
+
+// TODO: If Rust had facilities for specifying arrray sizes with generic parameters,
+// this could be removed in favor of a more generalized RingBuffer.
+pub struct VoiceBuffer {
+    pub buffer: Box<[VoiceOutput; VOICE_BUFFER_LEN]>,
+    pub pos: i32
+}
+
+impl VoiceBuffer {
+    pub fn new() -> VoiceBuffer {
+        VoiceBuffer {
+            buffer: Box::new([VoiceOutput::default(); VOICE_BUFFER_LEN]),
+            pos: 0
+        }
+    }
+
+    pub fn reset(&mut self) {
+        for i in 0..VOICE_BUFFER_LEN {
+            self.buffer[i] = VoiceOutput::default();
+        }
+        self.pos = 0;
+    }
+
+    pub fn write(&mut self, value: VoiceOutput) {
+        self.buffer[self.pos as usize] = value;
+        self.pos = (self.pos + 1) % (VOICE_BUFFER_LEN as i32);
+    }
 }
 
 pub struct Voice {
@@ -33,6 +74,7 @@ pub struct Voice {
     current_sample: i32,
     next_sample: i32,
 
+    pub output_buffer: Box<VoiceBuffer>,
     pub is_muted: bool
 }
 
@@ -61,7 +103,8 @@ impl Voice {
             current_sample: 0,
             next_sample: 0,
 
-            is_muted: false
+            output_buffer: Box::new(VoiceBuffer::new()),
+            is_muted: false,
         };
         ret.reset();
         ret
@@ -100,6 +143,7 @@ impl Voice {
         self.current_sample = 0;
         self.next_sample = 0;
 
+        self.output_buffer.reset();
         self.is_muted = false;
     }
 
@@ -147,19 +191,22 @@ impl Voice {
             }
         }
 
-        if !self.is_muted {
-            VoiceOutput {
-                left_out: dsp_helpers::multiply_volume(sample, self.vol_left),
-                right_out: dsp_helpers::multiply_volume(sample, self.vol_right),
-                last_voice_out: sample
-            }
-        } else {
-            VoiceOutput {
-                left_out: 0,
-                right_out: 0,
-                last_voice_out: 0
-            }
-        }
+        let ret =
+            if !self.is_muted {
+                VoiceOutput {
+                    left_out: dsp_helpers::multiply_volume(sample, self.vol_left),
+                    right_out: dsp_helpers::multiply_volume(sample, self.vol_right),
+                    last_voice_out: sample
+                }
+            } else {
+                VoiceOutput {
+                    left_out: 0,
+                    right_out: 0,
+                    last_voice_out: 0
+                }
+            };
+        self.output_buffer.write(ret);
+        ret
     }
 
     pub fn set_pitch_high(&mut self, value: u8) {


### PR DESCRIPTION
Fixes #28, which is kindof an ongoing ticket anyways as I produce a debugger alongside this, so I think it's ok to close it at this point, as it doesn't really have a definition of "done".
